### PR TITLE
ci: upgrade go version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,16 +1,21 @@
 name: build
 on:
+  pull_request:
+    branches:
+      - '*'
   push:
     branches:
       - main
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v3
+      
+      - uses: actions/setup-go@v4
         with:
-          go-version: "~1.16"
-      - name: build
-        run: |
-          go build .
+          go-version: "~1.24"
+          
+      - name: Build
+        run: go build -v .

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,10 +8,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: "~1.16"
+          go-version: "~1.24"
       - name: build
         run: |
           go build .


### PR DESCRIPTION
This PR adds trigger to run on every PR. Also upgrades the go version on the build and publish actions.